### PR TITLE
Allow using register_enum as a decorator

### DIFF
--- a/django_enum_js/__init__.py
+++ b/django_enum_js/__init__.py
@@ -6,6 +6,7 @@ class EnumWrapper:
 
     def register_enum(self, enum_class):
         self.registered_enums[enum_class.__name__] = enum_class
+        return enum_class
 
     def _enum_to_dict(self, enum_class):
         return dict([(k,v) for k,v in enum_class.__dict__.items() if not k[:2] == '__'])


### PR DESCRIPTION
By returning the original class instance, it'd be possible to use `enum_wrapper.register_enum` as a decorator, making the usage cleaner while staying backwards compatible:

``` python
@enum_wrapper.register_enum
class MyAwesomeClass:
  pass
```
